### PR TITLE
Feature/example: Add M5Unified compatible example sketch (v0.0.3)

### DIFF
--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -13,7 +13,7 @@ void setup() {
     cfg.serial_baudrate = 115200;
     M5.begin(cfg);
     sensor.begin();
-    canvas.createSprite(160, 80);
+    canvas.createSprite(M5.Display.width(), 80);
     canvas.setTextSize(2);
 }
 

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -1,21 +1,20 @@
 /*
   Display of rotary encoder values and key status on the screen
 */
-#include <M5Core2.h>
-#include <M5GFX.h>
+#include <M5Unified.h>
 #include "Unit_Encoder.h"
 
-M5GFX display;
-M5Canvas canvas(&display);
+M5Canvas canvas(&M5.Display);
 Unit_Encoder sensor;
 
 void setup() {
-    M5.begin(true, false, true, true);  // Init M5Core2.  初始化M5Core2
+    auto cfg = M5.config();
+    cfg.clear_display = true;
+    cfg.serial_baudrate = 115200;
+    M5.begin(cfg);
     sensor.begin();
-    display.begin();
-    display.setRotation(1);
-    canvas.setTextSize(2);
     canvas.createSprite(160, 80);
+    canvas.setTextSize(2);
 }
 
 signed short int last_value = 0;

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -11,11 +11,11 @@ void setup() {
     M5.begin(cfg);
     int ex_sda = M5.getPin(m5::ex_i2c_sda);
     int ex_scl = M5.getPin(m5::ex_i2c_scl);
-    Wire.begin(ex_sda, ex_scl);
     if (ex_sda >= 0 && ex_scl >= 0) {
-        Serial.println("Wire.begin(ex_sda, ex_scl) called");
-        sensor.begin(&Wire, ENCODER_ADDR, (uint8_t)ex_sda, (uint8_t)ex_scl); // I2C address for encoder: 0x40 (ENCODER_ADDR defined in Unit_Encoder.h)
+        Wire.begin(ex_sda, ex_scl);
+        sensor.begin(&Wire, ENCODER_ADDR, ex_sda, ex_scl); // I2C address for encoder: 0x40 (ENCODER_ADDR defined in Unit_Encoder.h)
     } else {
+        Wire.begin();
         sensor.begin(&Wire);
     }
     canvas.createSprite(M5.Display.width(), 80);

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -13,11 +13,10 @@ void setup() {
     int ex_scl = M5.getPin(m5::ex_i2c_scl);
     if (ex_sda >= 0 && ex_scl >= 0) {
         Wire.begin(ex_sda, ex_scl);
-        sensor.begin(&Wire, ENCODER_ADDR, ex_sda, ex_scl); // I2C address for encoder: 0x40 (ENCODER_ADDR defined in Unit_Encoder.h)
     } else {
         Wire.begin();
-        sensor.begin(&Wire);
     }
+    sensor.begin(&Wire);
     canvas.createSprite(M5.Display.width(), 80);
     canvas.setTextSize(2);
 }

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -12,11 +12,10 @@ void setup() {
     int ex_sda = M5.getPin(m5::ex_i2c_sda);
     int ex_scl = M5.getPin(m5::ex_i2c_scl);
     if (ex_sda >= 0 && ex_scl >= 0) {
-        Wire.begin(ex_sda, ex_scl);
+        sensor.begin(&Wire, ENCODER_ADDR, ex_sda, ex_scl); // I2C address for encoder: 0x40 (ENCODER_ADDR defined in Unit_Encoder.h)
     } else {
-        Wire.begin();
+        sensor.begin(&Wire);
     }
-    sensor.begin(&Wire);
     canvas.createSprite(M5.Display.width(), 80);
     canvas.setTextSize(2);
 }

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -9,7 +9,15 @@ void setup() {
     cfg.clear_display = true;
     cfg.serial_baudrate = 115200;
     M5.begin(cfg);
-    sensor.begin();
+    int ex_sda = M5.getPin(m5::ex_i2c_sda);
+    int ex_scl = M5.getPin(m5::ex_i2c_scl);
+    Wire.begin(ex_sda, ex_scl);
+    if (ex_sda >= 0 && ex_scl >= 0) {
+        Serial.println("Wire.begin(ex_sda, ex_scl) called");
+        sensor.begin(&Wire, ENCODER_ADDR, (uint8_t)ex_sda, (uint8_t)ex_scl); // I2C address for encoder: 0x40 (ENCODER_ADDR defined in Unit_Encoder.h)
+    } else {
+        sensor.begin(&Wire);
+    }
     canvas.createSprite(M5.Display.width(), 80);
     canvas.setTextSize(2);
 }

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -1,8 +1,5 @@
-/*
-  Display of rotary encoder values and key status on the screen
-*/
 #include <M5Unified.h>
-#include "Unit_Encoder.h"
+#include <Unit_Encoder.h>
 
 M5Canvas canvas(&M5.Display);
 Unit_Encoder sensor;
@@ -37,8 +34,11 @@ void loop() {
         sensor.setLEDColor(0, 0xC800FF);
     }
     canvas.fillSprite(BLACK);
-    canvas.drawString("BTN:" + String(btn_status), 10, 10);
-    canvas.drawString("ENCODER:" + String(encoder_value), 10, 40);
+    canvas.setCursor(0, 0);
+    canvas.print("BTN: ");
+    canvas.println(btn_status);
+    canvas.print("ENC: ");
+    canvas.println(encoder_value);
     canvas.pushSprite(0, 0);
     delay(20);
 }

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -1,0 +1,45 @@
+/*
+  Display of rotary encoder values and key status on the screen
+*/
+#include <M5Core2.h>
+#include <M5GFX.h>
+#include "Unit_Encoder.h"
+
+M5GFX display;
+M5Canvas canvas(&display);
+Unit_Encoder sensor;
+
+void setup() {
+    M5.begin(true, false, true, true);  // Init M5Core2.  初始化M5Core2
+    sensor.begin();
+    display.begin();
+    display.setRotation(1);
+    canvas.setTextSize(2);
+    canvas.createSprite(160, 80);
+}
+
+signed short int last_value = 0;
+
+void loop() {
+    signed short int encoder_value = sensor.getEncoderValue();
+    bool btn_status                = sensor.getButtonStatus();
+    Serial.println(encoder_value);
+    if (last_value != encoder_value) {
+        if (last_value > encoder_value) {
+            sensor.setLEDColor(1, 0x000011);
+        } else {
+            sensor.setLEDColor(2, 0x111100);
+        }
+        last_value = encoder_value;
+    } else {
+        sensor.setLEDColor(0, 0x001100);
+    }
+    if (!btn_status) {
+        sensor.setLEDColor(0, 0xC800FF);
+    }
+    canvas.fillSprite(BLACK);
+    canvas.drawString("BTN:" + String(btn_status), 10, 10);
+    canvas.drawString("ENCODER:" + String(encoder_value), 10, 40);
+    canvas.pushSprite(0, 0);
+    delay(20);
+}

--- a/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
+++ b/examples/Unit_Encoder_M5Unified/Unit_Encoder_M5Unified.ino
@@ -22,8 +22,8 @@ signed short int last_value = 0;
 void loop() {
     signed short int encoder_value = sensor.getEncoderValue();
     bool btn_status                = sensor.getButtonStatus();
-    Serial.println(encoder_value);
     if (last_value != encoder_value) {
+        Serial.println(encoder_value);
         if (last_value > encoder_value) {
             sensor.setLEDColor(1, 0x000011);
         } else {

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "https://github.com/m5stack/M5Unit-Encoder.git"
   },
-  "version": "0.0.2",
+  "version": "0.0.3",
   "frameworks": "arduino",
   "platforms": "espressif32"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=M5Unit-Encoder
-version=0.0.2
+version=0.0.3
 author=M5Stack
 maintainer=M5Stack
 sentence=Library for M5Stack Unit Encoder

--- a/src/Unit_Encoder.h
+++ b/src/Unit_Encoder.h
@@ -3,8 +3,6 @@
  * @copyright Copyright (c) 2022 by M5Stack[https://m5stack.com]
  *
  * @Links [Unit Encoder](https://docs.m5stack.com/en/unit/encoder)
- * @version  V0.0.2
- * @date  2022-07-11
  */
 #ifndef _UNIT_ENCODER_H_
 #define _UNIT_ENCODER_H_


### PR DESCRIPTION
---

### Update: Ready for Review (2026-04-03)

This PR is now out of draft. The M5Unified example has been verified on:
* M5Stack Core2, CoreS3, Basic, M5StickC Plus

Additionally, redundant `@version` and `@date` tags have been removed from source headers for better maintenance.

---

This PR introduces a new example sketch to demonstrate the use of the Unit Encoder with the M5Unified library. This is intended to offer a modern and unified way for users to integrate the Unit Encoder across different M5Stack host devices.

### Status and Request for Collaboration

* **Status:** The new example has been confirmed working on an **M5Stack Core2** (tested by the author).
* **Request:** Since this example utilizes M5Unified for cross-platform compatibility, I'd like to confirm its stability on at least one other M5Unified-supported host device before moving this PR out of draft status and requesting final review.

**I kindly request the community to help confirm the operation on one other M5Unified host (e.g., Basic, M5StickC Plus, CoreS3, M5Paper, etc.).**

Your confirmation (or bug report) in the comments would be greatly appreciated.

### Changes Included

* New example sketch for M5Unified integration.
* Version bump to v0.0.3 in `library.properties` and `library.json`.

---

### Quick way to get the code (for Testers)

To test this branch locally, please follow the steps appropriate for your environment.

1.  `git clone https://github.com/ito55/M5Unit-Encoder`
2.  `cd M5Unit-Encoder`
3.  `git switch feature/example-m5unified`